### PR TITLE
Fixed a regression introduced with epicam changes

### DIFF
--- a/src/XMLDocTrafic.cpp
+++ b/src/XMLDocTrafic.cpp
@@ -1444,7 +1444,7 @@ void XMLDocTrafic::AddTroncon(const std::string & strLibelle, Point* pPtAm, Poin
 
     // For EPiCAM : added the previous and next links in SYM_TRONCON nodes to help identify the CAF's internal trajectory a vehicle is on
     std::string upstreamLinkNames, downstreamLinkNames;
-    for (size_t iDownLink = 0; iDownLink < pTuyau->getConnectionAval()->m_LstTuyAv.size(); iDownLink++)
+    for (size_t iDownLink = 0; pTuyau->getConnectionAval() && iDownLink < pTuyau->getConnectionAval()->m_LstTuyAv.size(); iDownLink++)
     {
         if (iDownLink > 0)
         {
@@ -1452,7 +1452,7 @@ void XMLDocTrafic::AddTroncon(const std::string & strLibelle, Point* pPtAm, Poin
         }
         downstreamLinkNames += pTuyau->getConnectionAval()->m_LstTuyAv[iDownLink]->GetLabel();
     }
-    for (size_t iUpLink = 0; iUpLink < pTuyau->getConnectionAmont()->m_LstTuyAm.size(); iUpLink++)
+    for (size_t iUpLink = 0; pTuyau->getConnectionAmont() && iUpLink < pTuyau->getConnectionAmont()->m_LstTuyAm.size(); iUpLink++)
     {
         if (iUpLink > 0)
         {


### PR DESCRIPTION
The production of the new attributes "troncons_amont" et "troncons_aval" introduced for EPICAM could crash since some links do not have any upstream or downstream punctual node. This could happen only on poorly defined networks (when a link has an up/down complex node but is not referenced by any of the authorized moves at the complexe node).