### PR TITLE
Better absolute vehicle coords

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -27,6 +27,7 @@ class TuyauMicro;
 class TypeVehicule;
 class Connexion;
 class Voie;
+class VoieMicro;
 class Logger;
 
 namespace XERCES_CPP_NAMESPACE {
@@ -1300,7 +1301,7 @@ double GetDistance(Point pt1, Point pt2);
 bool IsCounterClockWise(Point *pt1, Point *pt2, Point *pt3);
 bool IsCounterClockWise(Point *V11, Point *V12, Point *V21, Point *V22);
 double AngleOfView( double ViewPt_X, double ViewPt_Y, double Pt1_X, double Pt1_Y, double Pt2_X, double Pt2_Y );
-std::deque<Point> BuildLineStringGeometry(const std::deque<Point> & lstPoints, double dbOffset, double dbTotalWidth, const std::string & strElementID, Logger * pLogger);
+std::deque<Point> BuildLineStringGeometry(const std::deque<Point> & lstPoints, double dbOffset, double dbTotalWidth, const std::string & strElementID, Logger * pLogger, VoieMicro * pVoie = nullptr);
 void CalculAbsCoords(Voie * pLane, double dbPos, bool bOutside, double & dbX, double & dbY, double & dbZ);
 double CalculAngleTuyau(Tuyau * pTuyau, double dbPos);
 

--- a/src/troncon.cpp
+++ b/src/troncon.cpp
@@ -579,7 +579,9 @@ void Troncon::serialize(Archive& ar, const unsigned int version)
 
     ar & BOOST_SERIALIZATION_NVP(m_LstTypesVehicule);
 
-    ar & BOOST_SERIALIZATION_NVP(m_mapTerrePleins);       
+    ar & BOOST_SERIALIZATION_NVP(m_mapTerrePleins);
+
+    ar & BOOST_SERIALIZATION_NVP(m_mapPointIndexByLength);
 }
 
 

--- a/src/troncon.h
+++ b/src/troncon.h
@@ -111,7 +111,7 @@ protected:
 
         std::string m_strRoadLabel;         // Libellé de la route correspondante
 
-        std::map<double, size_t> m_mapPointIndexByLength; // correspondance entre la longueur atteinte par le tronçon et l'indice du point associé dans sa polyligne 
+        std::map<double, std::pair<size_t, size_t> > m_mapPointIndexByLength; // correspondance entre la longueur atteinte par le tronçon et l'indice du point associé dans sa polyligne 
                 
 public:
         std::map<int, std::vector<TerrePlein>* > m_mapTerrePleins; // map des terre-pleins (liste de variations temporelles par voie)
@@ -240,8 +240,8 @@ public:
         void            SetRoadLabel(const std::string & strRoadLabel) { m_strRoadLabel = strRoadLabel;}
         std::string     GetRoadLabel() { return m_strRoadLabel;}
 
-        const std::map<double, size_t> & GetMapPointIndexByLength() const { return m_mapPointIndexByLength; }
-        void SetMapPointIndexByLength(const std::map<double, size_t> & mapPointIndexByLength) { m_mapPointIndexByLength = mapPointIndexByLength; }
+        const std::map<double, std::pair<size_t, size_t> > & GetMapPointIndexByLength() const { return m_mapPointIndexByLength; }
+        void SetMapPointIndexByLength(const std::map<double, std::pair<size_t, size_t> > & mapPointIndexByLength) { m_mapPointIndexByLength = mapPointIndexByLength; }
 
 public:
 

--- a/src/troncon.h
+++ b/src/troncon.h
@@ -110,6 +110,8 @@ protected:
 		std::deque<TypeVehicule*>       m_LstTypesVehicule;                     // Liste des types de véhicule pouvant emprunter le tronçon
 
         std::string m_strRoadLabel;         // Libellé de la route correspondante
+
+        std::map<double, size_t> m_mapPointIndexByLength; // correspondance entre la longueur atteinte par le tronçon et l'indice du point associé dans sa polyligne 
                 
 public:
         std::map<int, std::vector<TerrePlein>* > m_mapTerrePleins; // map des terre-pleins (liste de variations temporelles par voie)
@@ -237,6 +239,9 @@ public:
 
         void            SetRoadLabel(const std::string & strRoadLabel) { m_strRoadLabel = strRoadLabel;}
         std::string     GetRoadLabel() { return m_strRoadLabel;}
+
+        const std::map<double, size_t> & GetMapPointIndexByLength() const { return m_mapPointIndexByLength; }
+        void SetMapPointIndexByLength(const std::map<double, size_t> & mapPointIndexByLength) { m_mapPointIndexByLength = mapPointIndexByLength; }
 
 public:
 

--- a/src/tuyau.cpp
+++ b/src/tuyau.cpp
@@ -1425,8 +1425,10 @@ double Tuyau::GetMaxVitReg(double dbInst, double dbPos, int numVoie)
         // Nom        
 		strTmp = m_strLabel + "V" + to_string(i+1);
 
+        pVoie->SetPropCom(m_pReseau, this, strTmp, m_strRevetement );
+
         // Calcul des coordonnées géométriques
-        deque<Point> lstPoints = GetLineString(dbLargCum);
+        deque<Point> lstPoints = GetLineString(dbLargCum, pVoie);
 
         pVoie->SetExtAmont(lstPoints.front().dbX, lstPoints.front().dbY, lstPoints.front().dbZ);
         pVoie->SetExtAval(lstPoints.back().dbX, lstPoints.back().dbY, lstPoints.back().dbZ);
@@ -1443,9 +1445,7 @@ double Tuyau::GetMaxVitReg(double dbInst, double dbPos, int numVoie)
 
 		pas_espace = 1;//Alain
         if( m_nResolution == RESOTUYAU_MACRO )
-            pas_espace=GetLength()/m_nNbCell;
-
-        pVoie->SetPropCom(m_pReseau, this, strTmp, m_strRevetement );                                                                 
+            pas_espace=GetLength()/m_nNbCell;                                                          
 
         // Initialisation des vitesses max d'entrée et de sortie de la voie
         pVoie->SetVitMaxEntree(GetVitesseMax());
@@ -1490,7 +1490,8 @@ std::deque<Point> Tuyau::GetLineString
 // Historique: 21/04/2015 (O.Tonck - Ipsis)
 //================================================================
 (
-    double offset
+    double offset,
+    VoieMicro * pVoie
 )
 {
     std::deque<Point> result;
@@ -1521,7 +1522,7 @@ std::deque<Point> Tuyau::GetLineString
     pt.dbZ = GetHautAval();
     dqPoints.push_back(pt);
 
-    result = BuildLineStringGeometry(dqPoints, offset, dbLargTot, m_strLabel, m_pReseau->GetLogger());
+    result = BuildLineStringGeometry(dqPoints, offset, dbLargTot, m_strLabel, m_pReseau->GetLogger(), pVoie);
 
     return result;
 }

--- a/src/tuyau.cpp
+++ b/src/tuyau.cpp
@@ -1401,6 +1401,7 @@ double Tuyau::GetMaxVitReg(double dbInst, double dbPos, int numVoie)
 
     // Ménage
     DeleteLanes();
+    m_mapPointIndexByLength.clear();
 
     m_nRealNbVoies = m_nNbVoies;
 

--- a/src/tuyau.h
+++ b/src/tuyau.h
@@ -363,7 +363,7 @@ virtual        void            DeleteLanes() = 0;
 		bool		IsVoieReservee(TypeVehicule *pTV, int nVoie, double dbInst);
 
         // construit une polyligne correspondant à la géométrie du tronçon, à une position transversale donnée
-        std::deque<Point> GetLineString(double offset);
+        std::deque<Point> GetLineString(double offset, VoieMicro * pVoie = nullptr);
 
 
 


### PR DESCRIPTION
This PR includes changes made for Epicam in order to improve the absolute coordinates of the vehicle trajectories, in the case of multilane links that are not straight.

Previously, the absolute position of a vehicle in a lane was computed on the child lane linestring geometry, using the linear position of the vehicle along the lane's parent link (in symuvia, vehicle positions on a link are computed based on the link's length, and not the length of the lane the vehicle is in). Since the parent link's geometry and the lane geometry are offsetted, the length of each of their segments can be different (and is very different on curved roads).

This PR uses the parent link segments lengths to identify the current segment of the vehicle, and then consider the ratio of this segment's length for the link and the lane to use the correct linear coordinate to use against the geometry of the lane.